### PR TITLE
Fix: layout 에서 children이 두번씩 출력되는 문제 해결

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,8 +12,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body className={noto.className}>
+        <ReactQueryProvider>
         <main>{children}</main>
-        <ReactQueryProvider>{children}</ReactQueryProvider>
+        </ReactQueryProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
#8 

ReactQueryProvider 안에서 main 태그와 children 세팅되도록