### PR TITLE
TopNav의 뒤로가기, 닫기 버튼 option 으로 변경

### DIFF
--- a/src/components/common/TopNav.tsx
+++ b/src/components/common/TopNav.tsx
@@ -2,14 +2,28 @@
 import { useRouter } from "next/navigation";
 import React from "react";
 
-function TopNav({ title, path = "" }: { title: string; path?: string }) {
+function TopNav({
+  title,
+  hasBack,
+  hasClose,
+  closePath = "",
+}: {
+  title: string;
+  hasBack?: boolean;
+  hasClose?: boolean;
+  closePath?: string;
+}) {
   const router = useRouter();
 
   return (
-    <div className="fixed top-0 flex h-[40px] min-w-[425px]  items-center justify-between bg-[#d9d9d9] px-9">
-      <button onClick={() => router.back()}>&lt;</button>
+    <div className="fixed top-0 grid h-[40px] min-w-[425px] grid-cols-3 items-center bg-[#d9d9d9] px-[10px]">
+      <button className="text-left" onClick={() => router.back()}>
+        {hasBack && "<"}
+      </button>
       <span>{title}</span>
-      <button onClick={() => router.replace(path)}>X</button>
+      <button className="text-right" onClick={() => router.replace(closePath)}>
+        {hasClose && "X"}
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## 📌 관련 이슈
closed #50 

## ✨ 과제 내용
- TopNav의 뒤로가기 및 닫기 버튼을 option으로 변경

## 📸 스크린샷(선택)
Ex) 
- 두가지 버튼을 전부 사용할 때 
![image](https://github.com/FINALALT1/money-bridge/assets/75530371/5ea1ca83-948d-406e-971b-766a84428adc)

- 뒤로가기만 사용할 때 
![image](https://github.com/FINALALT1/money-bridge/assets/75530371/b9488aee-3f71-468f-870d-2c0c899c0ab0)

- 닫기만 사용할 때
![image](https://github.com/FINALALT1/money-bridge/assets/75530371/251803ea-ad30-4444-9fe3-0550fcee01bc)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
