### PR TITLE
PB리스트 첫 렌더링 시 params 적용 안되는 문제 해결

### DIFF
--- a/src/hooks/useGetFilteredPBList.ts
+++ b/src/hooks/useGetFilteredPBList.ts
@@ -58,8 +58,8 @@ export const useGetFilteredPBlist = () => {
   useEffect(() => {
     if (!isMounted) setIsMounted(true);
   }, []);
+
   useEffect(() => {
-    if (!isMounted) return;
     if (company) {
       const newParams = { ...params, sort: sortParam, company };
       if (newParams["speciality"]) {


### PR DESCRIPTION
## ✨ 과제 내용
PB리스트 첫 렌더링 시 params 적용 안되는 문제 해결


