### PR TITLE
Fix: refetchQueries로 수정

### DIFF
--- a/src/hooks/usePbBookMark.ts
+++ b/src/hooks/usePbBookMark.ts
@@ -9,11 +9,12 @@ const usePbBookMark = (bookmarkState: boolean, link: string, id: number | undefi
   const { isOpen, setIsOpen, error, errorHandler } = useErrorShow();
   const [isBookmark, setIsBookMark] = useState(bookmarkState);
   const [isBookmarkedOpen, setIsBookmarkedOpen] = useState(false);
-
+  const queryClient = useQueryClient();
   const router = useRouter();
+  
   const { mutate: postbookMarkPB } = useMutation(postBookMarkPB, {
     onSuccess: () => {
-      setIsBookMark(true);
+      queryClient.refetchQueries([queryKey, id]);
     },
     onError: (err: AxiosError) => {
       errorHandler(err);
@@ -22,7 +23,7 @@ const usePbBookMark = (bookmarkState: boolean, link: string, id: number | undefi
 
   const { mutate: deletebookMarkPB } = useMutation(deleteBookMarkPB, {
     onSuccess: () => {
-      setIsBookMark(false);
+      queryClient.refetchQueries([queryKey, id]);
     },
     onError: (err: AxiosError) => {
       errorHandler(err);


### PR DESCRIPTION
## ✨ 과제 내용
Fix: refetchQueries로 수정
북마크 페이지에서 북마크 해제 시 쿼리 무효화가 되질 않아 북마크 해제된 카드가 남아있음
